### PR TITLE
Feature/expand push api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.coveo</groupId>
     <artifactId>push-api-client.java</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <packaging>jar</packaging>
     <description>Coveo Push API client. See more on https://github.com/coveo/push-api-client.java</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.coveo</groupId>
     <artifactId>push-api-client.java</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <packaging>jar</packaging>
     <description>Coveo Push API client. See more on https://github.com/coveo/push-api-client.java</description>

--- a/src/main/java/com/coveo/pushapiclient/BatchIdentity.java
+++ b/src/main/java/com/coveo/pushapiclient/BatchIdentity.java
@@ -1,0 +1,42 @@
+package com.coveo.pushapiclient;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import java.util.List;
+
+/**
+ * See [Manage Batches of Security Identities](https://docs.coveo.com/en/55)
+ */
+public class BatchIdentity {
+
+    private List<SecurityIdentityModel> members;
+    private List<SecurityIdentityAliasModel> mappings;
+    private List<IdentityModel> deleted;
+
+    public BatchIdentity(List<SecurityIdentityModel> members, List<SecurityIdentityAliasModel> mappings, List<IdentityModel> deleted) {
+        this.members = members;
+        this.mappings = mappings;
+        this.deleted = deleted;
+    }
+
+    public BatchIdentityRecord marshal() {
+        return new BatchIdentityRecord(
+                this.members.stream().map(s -> new Gson().toJsonTree(s).getAsJsonObject()).toArray(JsonObject[]::new),
+                this.mappings.stream().map(s -> new Gson().toJsonTree(s).getAsJsonObject()).toArray(JsonObject[]::new),
+                this.deleted.stream().map(s -> new Gson().toJsonTree(s).getAsJsonObject()).toArray(JsonObject[]::new)
+        );
+    }
+
+    public List<SecurityIdentityModel> getMembers() {
+        return members;
+    }
+
+    public List<SecurityIdentityAliasModel> getMappings() {
+        return mappings;
+    }
+
+    public List<IdentityModel> getDeleted() {
+        return deleted;
+    }
+}

--- a/src/main/java/com/coveo/pushapiclient/BatchIdentityRecord.java
+++ b/src/main/java/com/coveo/pushapiclient/BatchIdentityRecord.java
@@ -1,0 +1,31 @@
+package com.coveo.pushapiclient;
+
+import com.google.gson.JsonObject;
+
+/**
+ * See [BatchIdentityBody](https://docs.coveo.com/en/139#batchidentitybody)
+ */
+public class BatchIdentityRecord {
+
+    private JsonObject[] members;
+    private JsonObject[] mappings;
+    private JsonObject[] deleted;
+
+    public BatchIdentityRecord(JsonObject[] members, JsonObject[] mappings, JsonObject[] deleted) {
+        this.members = members;
+        this.mappings = mappings;
+        this.deleted = deleted;
+    }
+
+    public JsonObject[] getMembers() {
+        return members;
+    }
+
+    public JsonObject[] getMappings() {
+        return mappings;
+    }
+
+    public JsonObject[] getDeleted() {
+        return deleted;
+    }
+}

--- a/src/main/java/com/coveo/pushapiclient/BatchUpdate.java
+++ b/src/main/java/com/coveo/pushapiclient/BatchUpdate.java
@@ -11,9 +11,9 @@ import java.util.Objects;
 public class BatchUpdate {
 
     private final List<DocumentBuilder> addOrUpdate;
-    private final List<DocumentBuilder> delete;
+    private final List<DeleteDocument> delete;
 
-    public BatchUpdate(List<DocumentBuilder> addOrUpdate, List<DocumentBuilder> delete) {
+    public BatchUpdate(List<DocumentBuilder> addOrUpdate, List<DeleteDocument> delete) {
         this.addOrUpdate = addOrUpdate;
         this.delete = delete;
     }
@@ -21,7 +21,7 @@ public class BatchUpdate {
     public BatchUpdateRecord marshal() {
         return new BatchUpdateRecord(
                 this.addOrUpdate.stream().map(DocumentBuilder::marshalJsonObject).toArray(JsonObject[]::new),
-                this.delete.stream().map(DocumentBuilder::marshalJsonObject).toArray(JsonObject[]::new)
+                this.delete.stream().map(DeleteDocument::marshalJsonObject).toArray(JsonObject[]::new)
         );
     }
 
@@ -29,7 +29,7 @@ public class BatchUpdate {
         return addOrUpdate;
     }
 
-    public List<DocumentBuilder> getDelete() {
+    public List<DeleteDocument> getDelete() {
         return delete;
     }
 

--- a/src/main/java/com/coveo/pushapiclient/DeleteDocument.java
+++ b/src/main/java/com/coveo/pushapiclient/DeleteDocument.java
@@ -1,0 +1,31 @@
+package com.coveo.pushapiclient;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+public class DeleteDocument {
+
+    /**
+     * The documentId of the document.
+     */
+    public String documentId;
+
+    /**
+     * Flag to delete children of the document.
+     */
+    public boolean deleteChildren;
+
+    public DeleteDocument(String documentId) {
+        this.documentId = documentId;
+        this.deleteChildren = false;
+    }
+
+    public DeleteDocument(String documentId, boolean deleteChildren) {
+        this.documentId = documentId;
+        this.deleteChildren = deleteChildren;
+    }
+
+    public JsonObject marshalJsonObject() {
+        return new Gson().toJsonTree(this).getAsJsonObject();
+    }
+}

--- a/src/main/java/com/coveo/pushapiclient/Document.java
+++ b/src/main/java/com/coveo/pushapiclient/Document.java
@@ -13,6 +13,7 @@ public class Document {
      * See https://docs.coveo.com/en/115 for more information.
      */
     public final HashMap<String, Object> metadata;
+
     /**
      * The list of permission sets for this item.
      * <p>
@@ -20,7 +21,8 @@ public class Document {
      * <p>
      * See https://docs.coveo.com/en/107 for more information.
      */
-    public final DocumentPermissions[] permissions;
+    public DocumentPermissions[] permissions;
+
     /**
      * The Uniform Resource Identifier (URI) that uniquely identifies the document in a Coveo index.
      * <p>
@@ -29,36 +31,48 @@ public class Document {
      * - `file://folder/text.txt`
      */
     public String uri;
+
+    /**
+     * The documentId of the document.
+     */
+    public String documentId;
+
     /**
      * The title of the document.
      */
     public String title;
+
     /**
      * The clickable URI associated with the document.
      */
     public String clickableUri;
+
     /**
      * The author of the document.
      */
     public String author;
+
     /**
      * The date of the document, represented as an ISO string.
      * <p>
      * Optional, will default to indexation date.
      */
     public String date;
+
     /**
      * The modified date of the document, represented as an ISO string.
      * <p>
      * Optional, will default to indexation date.
      */
     public String modifiedDate;
+
     /**
      * The permanent identifier of a document that does not change over time.
      * <p>
      * Optional, will be derived from the document URI.
      */
     public String permanentId;
+
     /**
      * The unique identifier (URI) of the parent item.
      * <p>
@@ -67,6 +81,7 @@ public class Document {
      * This value also ensures that a parent and all of its attachments will be routed in the same index slice.
      */
     public String parentId;
+
     /**
      * The textual (non-binary) content of the item.
      * <p>
@@ -79,18 +94,33 @@ public class Document {
      * Example: `This is a simple string that will be used for searchability as well as to generate excerpt and summaries for the document.`
      */
     public String data;
+
     /**
      * The original binary item content, compressed using one of the supported compression types (Deflate, GZip, LZMA, Uncompressed, or ZLib), and then Base64 encoded.
      * <p>
      * You can use this parameter when you're pushing a compressed binary item (such as XML/HTML, PDF, Word, or binary) whose size is less than 5 MB.
      * <p>
-     * Whenever you're pushing an item whose size is 5 MB or more, use the CompressedBinaryDataFileIdproperty instead.
+     * Whenever you're pushing an item whose size is 5 MB or more, use the CompressedBinaryDataFileId property instead.
      * <p>
      * If you're pushing less than 5 MB of textual (non-binary) content, you can use the data property instead.
      * <p>
      * See https://docs.coveo.com/en/73 for more information.
      */
     public CompressedBinaryData compressedBinaryData;
+
+    /**
+     * The fileId from the content that has been uploaded to the S3 via a FileContainer. The file is compressed using one of the supported compression types (Deflate, GZip, LZMA, Uncompressed, or ZLib).
+     * <p>
+     * You can use this parameter when you're pushing a compressed binary item (such as XML/HTML, PDF, Word, or binary) whose size is greater than 5 MB.
+     * <p>
+     * Whenever you're pushing an item whose size is less than 5 MB, use the CompressedBinaryData property instead.
+     * <p>
+     * If you're pushing less than 5 MB of textual (non-binary) content, you can use the data property instead.
+     * <p>
+     * See https://docs.coveo.com/en/73 for more information.
+     */
+    public String compressedBinaryDataFileId;
+
     /**
      * The file extension of the data you're pushing.
      * <p>

--- a/src/main/java/com/coveo/pushapiclient/DocumentBuilder.java
+++ b/src/main/java/com/coveo/pushapiclient/DocumentBuilder.java
@@ -170,6 +170,17 @@ public class DocumentBuilder {
     }
 
     /**
+     * Set the file container file ID for the compressed binary data of the document. See {@link Document#compressedBinaryDataFileId}
+     *
+     * @param compressedBinaryDataFileId
+     * @return
+     */
+    public DocumentBuilder withCompressedBinaryDataFileId(String compressedBinaryDataFileId) {
+        this.document.compressedBinaryDataFileId = compressedBinaryDataFileId;
+        return this;
+    }
+
+    /**
      * Set the file extension on the document. See {@link Document#fileExtension}
      *
      * @param fileExtension
@@ -303,6 +314,16 @@ public class DocumentBuilder {
      */
     public DocumentBuilder withAllowAnonymousUsers(Boolean allowAnonymous) {
         this.document.permissions[0].allowAnonymous = allowAnonymous;
+        return this;
+    }
+
+    /**
+     * Set the fully built out DocumentPermissions array. See {@Link Document#permissions}
+     * @param documentPermissions
+     * @return
+     */
+    public DocumentBuilder withDocumentPermissions(DocumentPermissions[] documentPermissions) {
+        this.document.permissions = documentPermissions;
         return this;
     }
 

--- a/src/main/java/com/coveo/pushapiclient/Environment.java
+++ b/src/main/java/com/coveo/pushapiclient/Environment.java
@@ -1,0 +1,21 @@
+package com.coveo.pushapiclient;
+
+/**
+ * Available environments to use as the host for the PushAPI.
+ */
+public enum Environment {
+    PRODUCTION( "https://api.cloud.coveo.com"),
+    HIPAA("https://apihipaa.cloud.coveo.com"),
+    DEVELOPMENT("https://apidev.cloud.coveo.com"),
+    STAGING("https://apiqa.cloud.coveo.com");
+
+    private String host;
+
+    Environment(String host) {
+        this.host = host;
+    }
+
+    public String getHost() {
+        return this.host;
+    }
+}

--- a/src/main/java/com/coveo/pushapiclient/PushAPIStatus.java
+++ b/src/main/java/com/coveo/pushapiclient/PushAPIStatus.java
@@ -1,0 +1,11 @@
+package com.coveo.pushapiclient;
+
+/**
+ * Enum for possible PushAPI statuses. See [Updating the Status of a Push Source](https://docs.coveo.com/en/35).
+ */
+public enum PushAPIStatus {
+    IDLE,
+    REBUILD,
+    INCREMENTAL,
+    REFRESH;
+}

--- a/src/main/java/com/coveo/pushapiclient/SecurityIdentityBatchResponse.java
+++ b/src/main/java/com/coveo/pushapiclient/SecurityIdentityBatchResponse.java
@@ -1,0 +1,28 @@
+package com.coveo.pushapiclient;
+
+import java.net.http.HttpResponse;
+
+/**
+ * Used for the responses when pushing batches of Security Identities. See [Manage Batches of Security Identities](https://docs.coveo.com/en/55)
+ */
+public class SecurityIdentityBatchResponse {
+
+    protected HttpResponse<String> s3Response;
+    protected HttpResponse<String> batchResponse;
+
+    public HttpResponse<String> getS3Response() {
+        return s3Response;
+    }
+
+    public void setS3Response(HttpResponse<String> s3Response) {
+        this.s3Response = s3Response;
+    }
+
+    public HttpResponse<String> getBatchResponse() {
+        return batchResponse;
+    }
+
+    public void setBatchResponse(HttpResponse<String> batchResponse) {
+        this.batchResponse = batchResponse;
+    }
+}

--- a/src/test/java/com/coveo/pushapiclient/BatchUpdateTest.java
+++ b/src/test/java/com/coveo/pushapiclient/BatchUpdateTest.java
@@ -38,9 +38,21 @@ public class BatchUpdateTest {
         list3.add(db3);
         list3.add(db4);
 
-        batch1 = new BatchUpdate(list1, list2);
-        batch2 = new BatchUpdate(list1, list2);
-        batch3 = new BatchUpdate(list2, list3);
+        DeleteDocument del1 = new DeleteDocument("123");
+        DeleteDocument del2 = new DeleteDocument("456");
+        DeleteDocument del3 = new DeleteDocument("789");
+
+        List<DeleteDocument> delList1 = new ArrayList<>();
+        delList1.add(del1);
+        delList1.add(del2);
+
+        List<DeleteDocument> delList2 = new ArrayList<>();
+        delList2.add(del2);
+        delList2.add(del3);
+
+        batch1 = new BatchUpdate(list1, delList1);
+        batch2 = new BatchUpdate(list1, delList1);
+        batch3 = new BatchUpdate(list2, delList2);
         batch4 = batch1;
     }
 


### PR DESCRIPTION
Changes included:
Downgraded codebase to Java 11. This mostly entailed altering records to traditional Java classes.
Added missing endpoint integrations, particularly for pushing batches of Security Identities, deleting documents, pushing binary files to a File Container, and setting Push API Status.
Added support for multiple environments, each having a different domain.